### PR TITLE
AppleTVOS platform build fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,8 @@ else ifeq ($(platform), tvos-arm64)
 ifeq ($(IOSSDK),)
    IOSSDK := $(shell xcodebuild -version -sdk appletvos Path)
 endif
+   CC = cc -arch arm64 -isysroot $(IOSSDK)
+   CXX = c++ -arch arm64 -isysroot $(IOSSDK)
 
 # QNX
 else ifneq (,$(findstring qnx,$(platform)))


### PR DESCRIPTION
Fixes building for Apple TVOS due to incorrect sysroot and arch for CC and CXX compiler vars

Sample error build log

```
15:11:56 clang: warning: using sysroot for 'AppleTVOS' but targeting 'iPhone' [-Wincompatible-sysroot]
15:11:56 clang: warning: using sysroot for 'AppleTVOS' but targeting 'iPhone' [-Wincompatible-sysroot]
15:11:56 clang: clang: warningwarning: using sysroot for 'AppleTVOS' but targeting 'iPhone' [-Wincompatible-sysroot]
15:11:56 : using sysroot for 'AppleTVOS' but targeting 'iPhone' [-Wincompatible-sysroot]
15:11:56 clang: clang: warning: using sysroot for 'AppleTVOS' but targeting 'iPhone' [-Wincompatible-sysroot]
15:11:56 warning: using sysroot for 'AppleTVOS' but targeting 'iPhone' [-Wincompatible-sysroot]
15:11:56 warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead [-Wstdlibcxx-not-found]
15:11:56 warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead [-Wstdlibcxx-not-found]
15:11:56 warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead [-Wstdlibcxx-not-found]
15:11:56 warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead [-Wstdlibcxx-not-found]
15:11:56 warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead [-Wstdlibcxx-not-found]
15:11:56 warning: include path for stdlibc++ headers not found; pass '-stdlib=libc++' on the command line to use the libc++ standard library instead [-Wstdlibcxx-not-found]
15:11:56 ai/GridFunctions.cpp:1:10: fatal error: 'vector' file not found
15:11:56 #include <vector>
15:11:56          ^~~~~~~~
15:11:56 retro.cpp:2:10: fatal error: 'vector' file not found
15:11:56 #include <vector>
15:11:56          ^~~~~~~~
15:11:56 In file included from ai/BotTree.cpp:2:
15:11:56 In file included from ./ai/Bot.hpp:3:
15:11:56 ./ai/GridFunctions.hpp:5:10: fatal error: 'algorithm' file not found
15:11:56 #include <algorithm>    // std::min
15:11:56          ^~~~~~~~~~~
```

Tested with Kodi libretro implementation on AppleTVOS 13.1 using Xcode 11